### PR TITLE
PB-1854 Add GitHub workflow creating release on push

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,10 @@
+name: on-push
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    uses: geoadmin/.github/.github/workflows/semver-release.yml@master


### PR DESCRIPTION
In a nutshell, this creates a new GitHub release based on a git tag that is incremented by one, based on what we put into the PR title (nothing means "minor" update). It follows the SemVer 2.0 specs as detailed in our [versioning/release guidelines](https://github.com/geoadmin/doc-guidelines/blob/master/VERSIONING_RELEASE.md#semver-20).

This workflow is exactly the same as the one in GitHub repository [template-service-semver-public](https://github.com/geoadmin/template-service-semver-public), except that it only applies on the `master` branch (we don't have a `develop` branch here).

This should have been added by Terraform when changing from template `infra-repository` to `service-repository-semver`. It wasn't probably becasue the repository already existed, so it did not add the `.github` folder with the workflows.