### PR TITLE
PB-1798 Rework content of page JS API

### DIFF
--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -2,6 +2,8 @@
 
 The GeoAdmin JS API extends OpenLayers with Swiss specific configurations and layers.
 
+For more details, see [the GeoAdmin JS API specs](https://geoadmin.github.io/ol3/apidoc/).
+
 ::: warning
 
 The GeoAdmin JS API is about to be decommissioned and is not updated anymore.

--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -6,7 +6,7 @@ The GeoAdmin JS API extends OpenLayers with Swiss specific configurations and la
 
 The GeoAdmin JS API is about to be decommissioned and is not updated anymore.
 The default version is based on OpenLayers 3.6.0 from 2015.
-We strongly recommend using a different web mapping framework implementing the OGC WMTS, like Leaflet.
+We strongly recommend using a different web mapping framework implementing the OGC WMTS, like Leaflet or plain OpenLayers.
 :::
 
 ## Available Versions

--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -1,43 +1,22 @@
-# JS API Doc
+# JS API
 
 The GeoAdmin JS API extends OpenLayers with Swiss specific configurations and layers.
 
 ::: warning
 
-The GeoAdmin JS API is now very mature and not updated anymore. It’s default version is based on Openlayers 3.6.0 (released on 7 Jun 2015), and the subsequent ones on Openlayers 3.18.2 (1 Sep 2016) and 4.4.2 (released on 6 Oct 2017). We urge you to use your favorite webmapping framework for new development, like OpenLayers , Leaflets , Google Maps, Yandex Map, Bing Map or anything implementing the OGC WMTS
-
+The GeoAdmin JS API is about to be decommissioned and is not updated anymore.
+The default version is based on OpenLayers 3.6.0 from 2015.
+We strongly recommend using a different web mapping framework implementing the OGC WMTS, like Leaflet.
 :::
 
-The API is available in multiple versions:
+## Available Versions
 
-Versions using LV95:
+The version of the GeoAdmin JS API corresponds to the version of OpenLayers it extends.
+The following versions of the GeoAdmin JS API are available:
 
-- 4.4.2
-
-Versions using LV03:
-
-- 4.3.2
-
-- 3.18.2
-
-- 3.6.0 (default)
-
-The version number refers to the same version in OpenLayers.
-
-You can access a specific version using the version parameter in the url of the loader:
-
-https://api3.geo.admin.ch/loader.js?version=4.4.2
-
-https://api3.geo.admin.ch/loader.js?version=4.3.2
-
-https://api3.geo.admin.ch/loader.js?version=3.18.2
-
-https://api3.geo.admin.ch/loader.js (default: 3.6.0)
-
-More examples of use are available on the API Examples page.
-
-Other useful links:
-
-- [GeoAdmin API documentation](http://geoadmin.github.io/ol3/apidoc/)
-
-- OpenLayers API documentation: for [version 3](https://openlayers.org/en/v3.20.1/doc/) or [version 4](https://openlayers.org/en/v4.6.5/doc/)
+- Versions using LV95:
+  - 4.4.2 → https://api3.geo.admin.ch/loader.js?version=4.4.2
+- Versions using LV03:
+  - 4.3.2 → https://api3.geo.admin.ch/loader.js?version=4.3.2 
+  - 3.18.2 → https://api3.geo.admin.ch/loader.js?version=3.18.2
+  - 3.6.0 (default) → https://api3.geo.admin.ch/loader.js


### PR DESCRIPTION
The original content of this page is copy-paste from the page ["JS API Doc" on api3](https://api3.geo.admin.ch/api/doc.html).

I tried to reduce the overly verbose text to the essential. This is going to be decommissioned soon, so we don't want to extend this further if possible.

However, we might want to include the examples from the [API Examples page](https://api3.geo.admin.ch/api/examples.html). It's not clear at that moment what to keep from there, so that is for later.

It might make sense to keep the link to the page https://geoadmin.github.io/ol3/apidoc/ but I am not sure what that is. Is it the detailed specs for the JS API?