### PR TITLE
PB-1798 Change title to be more self-explaining #patch

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -181,7 +181,7 @@ function downloadDataItems(): DefaultTheme.SidebarItem[] {
 
 function mapViewerItems(): DefaultTheme.SidebarItem[] {
   return [
-    { text: "iframe", link: "/docs/iframe" },
+    { text: "Embed in an iframe", link: "/docs/embed-in-an-iframe" },
     { text: "URL Parameters", link: "/docs/url-parameters" },
     {
       text: "Javascript API",

--- a/docs/embed-in-an-iframe.md
+++ b/docs/embed-in-an-iframe.md
@@ -1,4 +1,4 @@
-# iframe
+# Embed in an iframe
 
 You can embed an interactive version of the [map viewer](https://map.geo.admin.ch/) into your webpage using an HTML iframe, as shown below:
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -8,7 +8,7 @@ We provide tutorials on how to interact with these services:
 - [Access Data](/docs/identify-features): Retrieve location-based features such as geometries, addresses and elevation.
 - [Visualize Data](/docs/wmts): Access map data (2D and 3D) for visualization in your application.
 - [Download Data](/docs/stac/overview): Download entire datasets for exploration and analysis.
-- [Map Viewer](/docs/iframe): Embed the [map viewer](https://map.geo.admin.ch/) in your webpage.
+- [Map Viewer](/docs/embed-in-an-iframe): Embed the [map viewer](https://map.geo.admin.ch/) in your webpage.
 
 The tutorials are written for a tech-savvy audience like geoinformaticians, data scientists and web developers.
 


### PR DESCRIPTION
This changes the rather technical title of page "iframe" to the more self-explaining "Embed in an iframe".

I thought about "Embedding in an iframe" but using a verb is more in line with the other pages like "Indentify Features", "Get HTML Popup" etc. Also, it's shorter.

This is another mini PR that is mostly to test the CI/CD being developed in PB-1798.