### PR TITLE
PB-1798 Expand title "JS API" to "Javascript API" #patch

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -184,8 +184,8 @@ function mapViewerItems(): DefaultTheme.SidebarItem[] {
     { text: "iframe", link: "/docs/iframe" },
     { text: "URL Parameters", link: "/docs/url-parameters" },
     {
-      text: "JS API",
-      link: "/docs/js-api",
+      text: "Javascript API",
+      link: "/docs/javascript-api",
     },
   ];
 }

--- a/docs/javascript-api.md
+++ b/docs/javascript-api.md
@@ -1,6 +1,6 @@
-# JS API
+# Javascript API
 
-The GeoAdmin JS API extends OpenLayers with Swiss specific configurations and layers.
+The GeoAdmin Javascript API ("JS API") extends OpenLayers with Swiss specific configurations and layers.
 
 For more details, see [the GeoAdmin JS API specs](https://geoadmin.github.io/ol3/apidoc/).
 


### PR DESCRIPTION
A mini PR to test the CI/CD being developped in PB-1798.

This changes the title of page "JS API" to "Javascript API". That removes any ambiguity from it and makes it clearer why this belongs to the Mapviewer section. Otherwise one might think that this is another API to get geodata.