### PR TITLE
PB-1877 Add test link to PR #patch

### DIFF
--- a/.github/workflows/add-testlink-to-pr.yml
+++ b/.github/workflows/add-testlink-to-pr.yml
@@ -1,0 +1,22 @@
+name: Create test link on PR creation
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+jobs:
+  update_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create/update test link on DEV
+        uses: tzkhan/pr-update-action@v2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          head-branch-regex: '.+'
+          body-template: |
+
+            [Test link](https://sys-docs.dev.bgdi.ch/preview/%headbranch%/index.html)
+          body-update-action: 'suffix'
+          body-uppercase-head-match: false


### PR DESCRIPTION
This is adapted from the web-mapviewer.

We only have feature branches and a master branch. So no conditionals needed.

The preview link points to something like https://sys-docs.dev.bgdi.ch/preview/feat-PB-1877-my-title/index.html which points to S3 bucket `s3://tech-docs-dev-swisstopo`.

The corresponding CodeBuild project, S3 bucket and CloudFront configs are set up in https://github.com/geoadmin/infra-terraform-bgdi/pull/1179.

[Test link](https://sys-docs.dev.bgdi.ch/preview/feat-pb-1877-ci-cd-test-link-in-pr/index.html)