### PR TITLE
PB-1877 Directly link to Terms of Use

### DIFF
--- a/docs/embed-in-an-iframe.md
+++ b/docs/embed-in-an-iframe.md
@@ -7,7 +7,8 @@ You can embed an interactive version of the [map viewer](https://map.geo.admin.c
 The following expands on the introduction given in the [Web Integration: iFrame](https://www.geo.admin.ch/de/web-integration-iframe/) page.
 
 :::tip ⚖️ Terms of Use
-Refer to the corresponding section on the [Web Integration: iFrame](https://www.geo.admin.ch/de/web-integration-iframe/) page.
+When embedding the map viewer using an iframe, you must comply with the [Terms of Use for geo.admin.ch](https://www.geo.admin.ch/en/general-terms-of-use-fsdi).
+Please review these terms before implementation to ensure your use case is permitted.
 :::
 
 ## Add a legend


### PR DESCRIPTION
This changes a link on the "Embed in an iframe" to point to [the General Terms of Use of geo.admin.ch](https://www.geo.admin.ch/en/general-terms-of-use-fsdi). Before, it pointed to the iFrame page of the CMS.

This is labelled with PB-1877 because it's a small fix that I want to use to test whether CodeBuild etc works as expected. Ultimately, the PR out of this change should contain a description with a preview link to a version on DEV of the Tech Docs that corresponds to the status of the branch.

See https://github.com/geoadmin/infra-terraform-bgdi/pull/1179 and https://github.com/geoadmin/doc-tech/pull/40.