### PR TITLE
PB-1877 Directly link to Terms of Use #patch

### DIFF
--- a/docs/embed-in-an-iframe.md
+++ b/docs/embed-in-an-iframe.md
@@ -7,7 +7,8 @@ You can embed an interactive version of the [map viewer](https://map.geo.admin.c
 The following expands on the introduction given in the [Web Integration: iFrame](https://www.geo.admin.ch/de/web-integration-iframe/) page.
 
 :::tip ⚖️ Terms of Use
-Refer to the corresponding section on the [Web Integration: iFrame](https://www.geo.admin.ch/de/web-integration-iframe/) page.
+When embedding the map viewer using an iframe, you must comply with the [Terms of Use for geo.admin.ch](https://www.geo.admin.ch/en/general-terms-of-use-fsdi).
+Please review these terms before implementation to ensure your use case is permitted.
 :::
 
 ## Add a legend


### PR DESCRIPTION
This changes a link on the "Embed in an iframe" to point to [the General Terms of Use of geo.admin.ch](https://www.geo.admin.ch/en/general-terms-of-use-fsdi). Before, it pointed to the [iFrame page](https://www.geo.admin.ch/de/web-integration-iframe/) of the CMS.

This is to test the changes made in the CI here:

- https://github.com/geoadmin/infra-terraform-bgdi/pull/1179
- https://github.com/geoadmin/doc-tech/pull/40.

Creation of the PR should:
1. Trigger CodeBuild project `[doc-tech-pr](https://974517877189-54ujtveq.eu-central-1.console.aws.amazon.com/codesuite/codebuild/974517877189/projects/doc-tech-pr/history?region=eu-central-1)` to build the website on the current Git branch.
2. Deploy (`aws s3 cp`) the build artifacts on `s3://doc-tech-dev-swisstopo`.
3. Add a link to the PR description: https://sys-docs.dev.bgdi.ch/preview/bug-pb-1877-fix-link-to-terms-of-use-in-iframe-page/index.html

[Test link](https://sys-docs.dev.bgdi.ch/preview/bug-pb-1877-fix-link-to-terms-of-use-in-iframe-page/index.html)