### PR TITLE
PB-1969 Improve Status Page #patch

### DIFF
--- a/page/status-page.md
+++ b/page/status-page.md
@@ -1,4 +1,4 @@
----
+  ---
 # Use the following variables to set the Current Status section in this page and the homepage preview
 # Set `type` to control the position and color of the homepage preview:
 #   - "info": bottom of the page, no color
@@ -13,6 +13,8 @@ outline: [2, 3]
 ---
 
 # Status Page
+
+This page provides the latest status updates for all *.geo.admin.ch web services, including ongoing incidents and a history of past events.
 
 ## Current Status
 

--- a/page/status-page.md
+++ b/page/status-page.md
@@ -1,17 +1,31 @@
-  ---
-# Use the following variables to set the Current Status section in this page and the homepage preview
-# Set `type` to control the position and color of the homepage preview:
-#   - "info": bottom of the page, no color
-#   - "warning": top of the page, yellow
-#   - "danger": top of the page, red
-# The `title` is not displayed in the homepage preview for 'info' type
+---
 type: "info"
 title: "All Systems Operational"
 content: "No ongoing incidents - all services are functioning as expected."
 
 outline: [2, 3]
 ---
+<!---
+Templates:
 
+✅ Normal status: Status info is at the bottom of the start page
+
+type: "info"
+title: "All Systems Operational"
+content: "No ongoing incidents - all services are functioning as expected."
+
+⚠️ Minor incident: Status info as a yellow banner at the top of the start page
+
+type: "warning"
+title: "Minor incident"
+content: "We are currently investigating degraded performance in [Service XY]. Some users may experience intermittent issues. Updates will be posted as more information becomes available."
+
+🚨 Major incident: Status info as a red banner at the top of the start page
+
+type: "danger"
+title: "Major incident"
+content: "We are experiencing a significant outage affecting [Service XY]. All hands are on deck to diagnose and resolve the issue. The next update will be posted at XX:XX or as significant progress is made."
+--->
 # Status Page
 
 This page provides the latest status updates for all *.geo.admin.ch web services, including ongoing incidents and a history of past events.
@@ -22,7 +36,7 @@ This page provides the latest status updates for all *.geo.admin.ch web services
   {
     'info': '✅',
     'warning': '⚠️',
-    'danger': '❌'
+    'danger': '🚨'
   }[$frontmatter.type] || ''
 }} **{{ $frontmatter.title }}**: {{ $frontmatter.content }}
 


### PR DESCRIPTION
Changed two things in the [Status Page](https://sys-docs.int.bgdi.ch/page/status-page.html) based on feedback by @Luke252 in the [review page](https://swissgeoplatform.atlassian.net/wiki/spaces/PB/pages/190710179/2025-09-16+Tech+Docs+Review+by+PP-BGDI+IGKS) for the Tech Docs and by @stebie informally after the presentation by @pedroslvieira:
1. Add an introductory sentence to make it clear what this is about. I would keep the page titles short such that they fit into the navigation bar on the left.
2. Add templates for possible status messages in case of an incident. Once we are in the middle of an incident, we can save time by referring to these templates.