### PR TITLE
group incidents by year

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,33 @@ To add a release note, follow these steps:
    ```
 
 2. Save the file and commit your changes.
+
+## How to add a new incident details section
+
+1. Edit the file [`status-page.md`](./page/status-page.md)
+1. If there already is a section of the current year, such as e.g. `:::: details 2025 {open}`, add the incident on top of that section, leaving one blank line after the `:::: details 2025 {open}`
+1. If it is the first incident of the current year, create a new section for the new year, e.g. `:::: details 2026 {open}` and already the closing `::::`, so basically like this:
+
+   ```markdown
+   :::: details 2026 {open}
+
+   ::::
+   ```
+
+1. When you started a new year, please remove the `{open}` from the last year. This way, the old year is collapsed by default.
+1. Also, please remove the `{open}` from the last incident's details, this way, only the recent incident's details are expanded.
+1. Add the new incident either in the section of the new year or in the already existing section of the current year like this:
+
+   ```markdown
+   :::: details 2026 {open}
+
+   ::: details MONTH, DAY - short heading {open}
+
+   ### MONTH, DAY - longer heading
+
+   DETAILS go here
+   :::
+   ::::
+   ```
+
+1. Remember to close the details section of the incident with three `:`, and in case you created a new year section, remember to close that one with four `:`.

--- a/README.md
+++ b/README.md
@@ -84,29 +84,28 @@ To add a release note, follow these steps:
 ## How to add a new incident details section
 
 1. Edit the file [`status-page.md`](./page/status-page.md)
-1. If there already is a section of the current year, such as e.g. `:::: details 2025 {open}`, add the incident on top of that section, leaving one blank line after the `:::: details 2025 {open}`
-1. If it is the first incident of the current year, create a new section for the new year, e.g. `:::: details 2026 {open}` and already the closing `::::`, so basically like this:
+1. If there already is a section of the current year, such as e.g. `::::: details 2025`, add the incident on top of that section, leaving one blank line after the `::::: details 2025`
+1. If it is the first incident of the current year, create a new section for the new year, e.g. `::::: details 2026 {open}` and already the closing `:::::`, so basically like this:
 
    ```markdown
-   :::: details 2026 {open}
+   ::::: details 2026 {open}
 
-   ::::
+   :::::
    ```
 
-1. When you started a new year, please remove the `{open}` from the last year. This way, the old year is collapsed by default.
-1. Also, please remove the `{open}` from the last incident's details, this way, only the recent incident's details are expanded.
 1. Add the new incident either in the section of the new year or in the already existing section of the current year like this:
 
    ```markdown
-   :::: details 2026 {open}
+   ::::: details 2026
 
-   ::: details MONTH, DAY - short heading {open}
+   :::: details MONTH, DAY(, TIME) - [SHORT HEADING OF THE INCIDENT]
 
-   ### MONTH, DAY - longer heading
+   ::: info MONTH, DAY(, Time) [LONGER HEADING OF THE INCIDENT]
 
-   DETAILS go here
+   [DETAILED TEXT ABOUT THE INCIDENT]
    :::
    ::::
+   :::::
    ```
 
-1. Remember to close the details section of the incident with three `:`, and in case you created a new year section, remember to close that one with four `:`.
+The five `:` are only when you start and end a new year, otherwise, only the part that starts and ends with four `:` is relevant for you.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To add a release note, follow these steps:
 ## How to add a new incident details section
 
 1. Edit the file [`status-page.md`](./page/status-page.md)
-1. If there already is a section of the current year, such as e.g. `::::: details 2025`, add the incident on top of that section, leaving one blank line after the `::::: details 2025`
+1. If there already is a section of the current year, such as e.g. `::::: details 2025 {open}`, add the incident on top of that section, leaving one blank line after the `::::: details 2025`
 1. If it is the first incident of the current year, create a new section for the new year, e.g. `::::: details 2026 {open}` and already the closing `:::::`, so basically like this:
 
    ```markdown
@@ -98,7 +98,7 @@ To add a release note, follow these steps:
    ```markdown
    ::::: details 2026
 
-   :::: details MONTH, DAY(, TIME) - [SHORT HEADING OF THE INCIDENT]
+   :::: details MONTH, DAY(, TIME) - [SHORT HEADING OF THE INCIDENT] {open}
 
    ::: info MONTH, DAY(, Time) [LONGER HEADING OF THE INCIDENT]
 

--- a/page/status-page.md
+++ b/page/status-page.md
@@ -47,11 +47,11 @@ This page provides the latest status updates for all \*.geo.admin.ch web service
 <!-- Please check the README.md for details on how to add new incidents or start a new year, thanks!
 -->
 
-:::: details 2025 {open}
+::::: details 2025
 
-::: details Nov 12 - Issues with search service {open}
+:::: details Nov 12 - Issues with search service
 
-### Nov 14 - Information on recent problems when changing address data from RBD to the official directory of building addresses
+::: info Nov 14 - Information on recent problems when changing address data from RBD to the official directory of building addresses
 
 On Wednesday, November 12, 2025, the Search Service was switched from the register of buildings and dwellings (RBD) to the new default data source of the official directory of building addresses.
 
@@ -70,14 +70,15 @@ On the SearchServer endpoint, you can either perform a type=featuresearch or a t
 For your information, there are three ways to perform an address search:
 
 1. Swisssearch search with origins=address; if desired, the feature ID can be transferred to the feature endpoint of the specialist layer ch.swisstopo.amtliches-gebaeudeadressverzeichnis
-1. FeatureSearch in the layer ch.swisstopo.amtliches-gebaeudeadressverzeichnis; if desired, the feature ID can be transferred to the feature endpoint of the thematic layer ch.swisstopo.amtliches-gebaeudeadressverzeichnis
-1. FeatureSearch in the layer ch.bfs.gebaeude_wohnungs_register; if desired, the feature ID can be transferred to the feature endpoint of the specialist layer ch.bfs.gebaeude_wohnungs_register.
+2. FeatureSearch in the layer ch.swisstopo.amtliches-gebaeudeadressverzeichnis; if desired, the feature ID can be transferred to the feature endpoint of the thematic layer ch.swisstopo.amtliches-gebaeudeadressverzeichnis
+3. FeatureSearch in the layer ch.bfs.gebaeude_wohnungs_register; if desired, the feature ID can be transferred to the feature endpoint of the specialist layer ch.bfs.gebaeude_wohnungs_register.
 
 Specific documentation for this topic: [Search | \*.geo.admin.ch](https://docs.geo.admin.ch/access-data/search.html#request-details)
 :::
-::: details Nov 12 - Incident with Service Stac
+::::
+:::: details Nov 12 - Incident with Service Stac
 
-### Nov 12, 19:15 - Disruption of Service Stac - Resolved
+::: info Nov 12, 19:15 - Disruption of Service Stac - Resolved
 
 The root cause that led to the outage of STAC API could be identified and resolved. The problem was a
 misconfigration of database logging that was done earlier today
@@ -85,14 +86,15 @@ that led to a rapid increase in log volume and eventually resulted in full disk 
 space has been increased and the logging configuration change rolled back.
 
 STAC API is functioning normal again.
-
-### Nov 12, 19:15 - Disruption of Service Stac
+:::
+::: info Nov 12, 19:15 - Disruption of Service Stac
 
 The STAC API on data.geo.admin.ch is currently unavailable. We're investigating the cause and will give an update later tonight.
 :::
-::: details July 2nd - Incident with Printing
+::::
+:::: details July 2nd - Incident with Printing
 
-### July 3, 10:00 - Incident Resolved
+::: info July 3, 10:00 - Incident Resolved
 
 An update to map.geo.admin.ch made on July 2, 2025 caused a temporarily disruption to the system's printing service.
 This resulted in a problem with the browser cache storing the information.
@@ -127,15 +129,16 @@ SAFARI
 
 - In Safari, go to "Settings" > "Advanced" and enable "Show Develop menu in menu bar."
 - Click on ‘Develop’ in the menu and then on "Empty Cache."
-
-### July 2, 16:00 - Incident Detected
+  :::
+  ::: info July 2, 16:00 - Incident Detected
 
 The printing functionality of map.geo.admin.ch is currently unavailable.
 We are analysing the problem and keep you updated on this page.
 :::
-::: details April 30 - Incident with WMS/WMTS
+::::
+:::: details April 30 - Incident with WMS/WMTS
 
-### May 6 - Root Cause Analysis
+::: info May 6 - Root Cause Analysis
 
 On the 30th of April and 1st of May, the WMS service and WMTS service provided by geo.admin.ch were restricted or unavailable, which also affected the print function in the map viewer.
 
@@ -147,16 +150,16 @@ The problem was resolved by our specialists by rolling out new system components
 We apologise for any inconvenience caused.
 
 Thank you for your understanding and patience.
-
-### May 1, 16:00 - Incident Resolved
+:::
+::: info May 1, 16:00 - Incident Resolved
 
 The disruption has been resolved.
 
 All services on \*geo.admin.ch are now available as usual.
 
 We thank you for your understanding and patience.
-
-### May 1, 12:00 - Update
+:::
+::: info May 1, 12:00 - Update
 
 No change since the update at 9:25 a.m.
 We are continuing to work intensively to resolve the problem.
@@ -164,8 +167,8 @@ We are continuing to work intensively to resolve the problem.
 The next update will be provided today at around 4 p.m. or as soon as the disruption has been resolved.
 
 We apologise for any inconvenience caused and thank you in advance for your patience.
-
-### May 1, 09:25 Update
+:::
+::: info May 1, 09:25 Update
 
 The extent of the disruption has been reduced in the meantime.
 Certain WMS layers and the printing service are still affected.
@@ -174,8 +177,8 @@ No other services provided by \*geo.admin.ch are affected. We are continuing to 
 The next update will be provided today at around 12 noon or as soon as the disruption has been resolved.
 
 We apologise for any inconvenience caused and thank you in advance for your patience.
-
-### April 30, 16:00 Update
+:::
+::: info April 30, 16:00 Update
 
 The disruption to the WMS, WMTS and print services is still ongoing.
 No other services provided by \*geo.admin.ch are affected.
@@ -184,8 +187,8 @@ We are working intensively to resolve the problem.
 The next update will be provided tomorrow, 1 May, at 9 a.m. or as soon as the disruption has been resolved.
 
 We apologise for any inconvenience caused and thank you in advance for your patience.
-
-### April 30, 12:00 Update
+:::
+::: info April 30, 12:00 Update
 
 The disruption to WMS and WMTS services is still ongoing.
 We are continuing to work hard to resolve the issue.
@@ -193,8 +196,8 @@ We are continuing to work hard to resolve the issue.
 The next update will be provided today at around 4 p.m. or as soon as the disruption has been resolved.
 
 We apologise for any inconvenience caused and thank you in advance for your patience.
-
-### April 30, 10:00 Incident Detected
+:::
+::: info April 30, 10:00 Incident Detected
 
 We are currently experiencing some problems with our WMS and WMTS services, which we are analysing and will resolve as quickly as possible.
 The duration of the disruption is still unknown.
@@ -205,3 +208,4 @@ The next update will be provided today at around 12 noon or as soon as the disru
 We apologise for any inconvenience caused and thank you in advance for your patience.
 :::
 ::::
+:::::

--- a/page/status-page.md
+++ b/page/status-page.md
@@ -44,6 +44,23 @@ This page provides the latest status updates for all \*.geo.admin.ch web service
 
 ## Incident History
 
+<!-- Once we are in 2026, we should do the following:
+1. add a new details section for 2026:
+   ::: details 2026 {open}
+    [add any new incidents here]
+    ### [2026-mm-dd] Incident XYZ
+    #### [2026-mm-dd] Iformation related to incident XYZ
+    bla bla bla
+   :::
+
+2. remove the {open} from the 2025 section, so that it is collapsed by default
+
+This will group all incidents by year, and only the current year is expanded, all older incidents
+are collapsed. Improves overview a bit, in case we have too many incidents in one single year ;-)
+-->
+
+::: details 2025 {open}
+
 ### [2025-11-12] Issues with search service
 
 #### [2025-11-14] Information on recent problems when changing address data from RBD to the official directory of building addresses
@@ -198,3 +215,4 @@ We will keep you updated on this page.
 The next update will be provided today at around 12 noon or as soon as the disruption has been resolved.
 
 We apologise for any inconvenience caused and thank you in advance for your patience.
+:::

--- a/page/status-page.md
+++ b/page/status-page.md
@@ -49,7 +49,7 @@ This page provides the latest status updates for all \*.geo.admin.ch web service
 
 ::::: details 2025
 
-:::: details Nov 12 - Issues with search service
+:::: details Nov 12 - Issues with search service {open}
 
 ::: info Nov 14 - Information on recent problems when changing address data from RBD to the official directory of building addresses
 
@@ -76,7 +76,7 @@ For your information, there are three ways to perform an address search:
 Specific documentation for this topic: [Search | \*.geo.admin.ch](https://docs.geo.admin.ch/access-data/search.html#request-details)
 :::
 ::::
-:::: details Nov 12 - Incident with Service Stac
+:::: details Nov 12 - Incident with Service Stac {open}
 
 ::: info Nov 12, 19:15 - Disruption of Service Stac - Resolved
 
@@ -92,7 +92,7 @@ STAC API is functioning normal again.
 The STAC API on data.geo.admin.ch is currently unavailable. We're investigating the cause and will give an update later tonight.
 :::
 ::::
-:::: details July 2nd - Incident with Printing
+:::: details July 2nd - Incident with Printing {open}
 
 ::: info July 3, 10:00 - Incident Resolved
 
@@ -136,7 +136,7 @@ The printing functionality of map.geo.admin.ch is currently unavailable.
 We are analysing the problem and keep you updated on this page.
 :::
 ::::
-:::: details April 30 - Incident with WMS/WMTS
+:::: details April 30 - Incident with WMS/WMTS {open}
 
 ::: info May 6 - Root Cause Analysis
 

--- a/page/status-page.md
+++ b/page/status-page.md
@@ -44,26 +44,14 @@ This page provides the latest status updates for all \*.geo.admin.ch web service
 
 ## Incident History
 
-<!-- Once we are in 2026, we should do the following:
-1. add a new details section for 2026:
-   ::: details 2026 {open}
-    [add any new incidents here]
-    ### [2026-mm-dd] Incident XYZ
-    #### [2026-mm-dd] Iformation related to incident XYZ
-    bla bla bla
-   :::
-
-2. remove the {open} from the 2025 section, so that it is collapsed by default
-
-This will group all incidents by year, and only the current year is expanded, all older incidents
-are collapsed. Improves overview a bit, in case we have too many incidents in one single year ;-)
+<!-- Please check the README.md for details on how to add new incidents or start a new year, thanks!
 -->
 
-::: details 2025 {open}
+:::: details 2025 {open}
 
-### [2025-11-12] Issues with search service
+::: details Nov 12 - Issues with search service {open}
 
-#### [2025-11-14] Information on recent problems when changing address data from RBD to the official directory of building addresses
+### Nov 14 - Information on recent problems when changing address data from RBD to the official directory of building addresses
 
 On Wednesday, November 12, 2025, the Search Service was switched from the register of buildings and dwellings (RBD) to the new default data source of the official directory of building addresses.
 
@@ -86,10 +74,10 @@ For your information, there are three ways to perform an address search:
 1. FeatureSearch in the layer ch.bfs.gebaeude_wohnungs_register; if desired, the feature ID can be transferred to the feature endpoint of the specialist layer ch.bfs.gebaeude_wohnungs_register.
 
 Specific documentation for this topic: [Search | \*.geo.admin.ch](https://docs.geo.admin.ch/access-data/search.html#request-details)
+:::
+::: details Nov 12 - Incident with Service Stac
 
-### [2025-11-12] Incident with Service Stac
-
-#### [2025-11-12 19:15] Disruption of Service Stac - Resolved
+### Nov 12, 19:15 - Disruption of Service Stac - Resolved
 
 The root cause that led to the outage of STAC API could be identified and resolved. The problem was a
 misconfigration of database logging that was done earlier today
@@ -98,13 +86,13 @@ space has been increased and the logging configuration change rolled back.
 
 STAC API is functioning normal again.
 
-#### [2025-11-12 19:15] Disruption of Service Stac
+### Nov 12, 19:15 - Disruption of Service Stac
 
 The STAC API on data.geo.admin.ch is currently unavailable. We're investigating the cause and will give an update later tonight.
+:::
+::: details July 2nd - Incident with Printing
 
-### [2025-07-02] Incident with Printing
-
-#### [2025-07-03 10:00] Incident Resolved
+### July 3, 10:00 - Incident Resolved
 
 An update to map.geo.admin.ch made on July 2, 2025 caused a temporarily disruption to the system's printing service.
 This resulted in a problem with the browser cache storing the information.
@@ -140,14 +128,14 @@ SAFARI
 - In Safari, go to "Settings" > "Advanced" and enable "Show Develop menu in menu bar."
 - Click on ‘Develop’ in the menu and then on "Empty Cache."
 
-#### [2025-07-02 16:00] Incident Detected
+### July 2, 16:00 - Incident Detected
 
 The printing functionality of map.geo.admin.ch is currently unavailable.
 We are analysing the problem and keep you updated on this page.
+:::
+::: details April 30 - Incident with WMS/WMTS
 
-### [2025-04-30] Incident with WMS/WMTS
-
-#### [2025-05-06] Root Cause Analysis
+### May 6 - Root Cause Analysis
 
 On the 30th of April and 1st of May, the WMS service and WMTS service provided by geo.admin.ch were restricted or unavailable, which also affected the print function in the map viewer.
 
@@ -160,7 +148,7 @@ We apologise for any inconvenience caused.
 
 Thank you for your understanding and patience.
 
-#### [2025-05-01, 16:00] Incident Resolved
+### May 1, 16:00 - Incident Resolved
 
 The disruption has been resolved.
 
@@ -168,7 +156,7 @@ All services on \*geo.admin.ch are now available as usual.
 
 We thank you for your understanding and patience.
 
-#### [2025-05-01, 12:00] Update
+### May 1, 12:00 - Update
 
 No change since the update at 9:25 a.m.
 We are continuing to work intensively to resolve the problem.
@@ -177,7 +165,7 @@ The next update will be provided today at around 4 p.m. or as soon as the disrup
 
 We apologise for any inconvenience caused and thank you in advance for your patience.
 
-#### [2025-05-01, 09:25] Update
+### May 1, 09:25 Update
 
 The extent of the disruption has been reduced in the meantime.
 Certain WMS layers and the printing service are still affected.
@@ -187,7 +175,7 @@ The next update will be provided today at around 12 noon or as soon as the disru
 
 We apologise for any inconvenience caused and thank you in advance for your patience.
 
-#### [2025-04-30, 16:00] Update
+### April 30, 16:00 Update
 
 The disruption to the WMS, WMTS and print services is still ongoing.
 No other services provided by \*geo.admin.ch are affected.
@@ -197,7 +185,7 @@ The next update will be provided tomorrow, 1 May, at 9 a.m. or as soon as the di
 
 We apologise for any inconvenience caused and thank you in advance for your patience.
 
-#### [2025-04-30, 12:00] Update
+### April 30, 12:00 Update
 
 The disruption to WMS and WMTS services is still ongoing.
 We are continuing to work hard to resolve the issue.
@@ -206,7 +194,7 @@ The next update will be provided today at around 4 p.m. or as soon as the disrup
 
 We apologise for any inconvenience caused and thank you in advance for your patience.
 
-#### [2025-04-30, 10:00] Incident Detected
+### April 30, 10:00 Incident Detected
 
 We are currently experiencing some problems with our WMS and WMTS services, which we are analysing and will resolve as quickly as possible.
 The duration of the disruption is still unknown.
@@ -216,3 +204,4 @@ The next update will be provided today at around 12 noon or as soon as the disru
 
 We apologise for any inconvenience caused and thank you in advance for your patience.
 :::
+::::


### PR DESCRIPTION
Suggestion:
How about grouping incidents by year and only expanding the current year by default, to improve readability?
Esp. useful in years with many incidents

[Test link](https://sys-docs.dev.bgdi.ch/preview/feat_group_incidents_by_year/index.html)