### PR TITLE
HDG-52 Make it clearer when to use STAC API

### DIFF
--- a/access-data/find-features.md
+++ b/access-data/find-features.md
@@ -4,6 +4,11 @@ Find features in a specific layer by searching for a matching attribute.
 
 <ApiCodeBlock url="https://api3.geo.admin.ch/rest/services/ech/MapServer/find" method="GET" />
 
+::: warning
+A maximum of 200 features can be retrieved per request.
+To download a larger number of features or entire datasets, use the file-based [STAC API](/download-data/stac-api/overview.md).
+:::
+
 ## Request Details
 
 To interact with the find features service, you need to provide specific parameters in your request.

--- a/access-data/identify-features.md
+++ b/access-data/identify-features.md
@@ -5,7 +5,8 @@ Use this endpoint to discover features at a specific location.
 <ApiCodeBlock url="https://api3.geo.admin.ch/rest/services/ech/MapServer/identify" method="GET" />
 
 ::: warning
-No more than 200 features can be retrieved per request.
+A maximum of 200 features can be retrieved per request.
+To download a larger number of features or entire datasets, use the file-based [STAC API](/download-data/stac-api/overview.md).
 :::
 
 ## Request Details

--- a/download-data/stac-api/overview.md
+++ b/download-data/stac-api/overview.md
@@ -1,6 +1,9 @@
 # Overview
 
 This documentation provides tutorials on how to use the STAC API of [data.geo.admin.ch](https://data.geo.admin.ch/).
+
+While other geo.admin.ch service endpoints are tailored for querying individual records and targeted vector features, the STAC API is optimized for discovering and downloading file-based data, typically entire datasets or specific spatial or temporal tiles.
+
 The STAC API consists of standardized RESTful API endpoints designed for interacting with federal geodata.
 All datasets are organized according to the [SpatioTemporal Asset Catalog](https://stacspec.org) (STAC) specification, which simplifies data discovery and usage.
 


### PR DESCRIPTION
According to support, people are often confused whether they should use feature-based API endpoints or the file-based STAC API. See [this recent Google group thread](https://groups.google.com/g/geoadmin-api/c/3fSpRamiF2c/m/aW6yn49mCAAJ) for example.

This change aims to improve clarity by changing these two sections:
- Page "Identify Features": Redirect to STAC API in the warning box about the maximum number of features.
- Page "STAC API" > "Overview": Add a section to clarify how STAC is different from the other service endpoints (api3).

CC @faselm

[Test link](https://sys-docs.dev.bgdi.ch/preview/hdg-52-improve-clarity-of-typical-stac-api-use-case/index.html)