### PR TITLE
Add incident log on what caused WM(T)S interruption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "doc-tech",
             "devDependencies": {
                 "@types/node": "24.10.14",
                 "fast-glob": "^3.3.3",

--- a/page/status-page.md
+++ b/page/status-page.md
@@ -46,6 +46,13 @@ This page provides the latest status updates for all \*.geo.admin.ch web service
 
 ### [2026-05-06] Issues with WMS and WMTS services
 
+###  [2026-05-06 11:30] Issues with WMS and WMTS solved
+
+The WMS and the WMTS are working again as expected.
+The incident was caused by a temporary IO overload on our network file system (EFS), triggered by a large internal data transfer.
+This caused the map server processes to stall while waiting for IO operations to complete.
+The issue was resolved by reducing the load on the file system.
+
 #### [2026-05-06 11:03] Issues with WMS and WMTS noticed
 
 We are currently experiencing issues with our WMS and WMTS services. Maps won't be loaded and the services response slowly or throw errors.

--- a/page/status-page.md
+++ b/page/status-page.md
@@ -46,11 +46,13 @@ This page provides the latest status updates for all \*.geo.admin.ch web service
 
 ### [2026-05-06] Issues with WMS and WMTS services
 
-###  [2026-05-06 11:30] Issues with WMS and WMTS solved
+#### [2026-05-06 11:30] Issues with WMS and WMTS solved
 
 The WMS and the WMTS are working again as expected.
-The incident was caused by a temporary IO overload on our network file system (EFS), triggered by a large internal data transfer.
+
+The incident was caused by a temporary IO overload on our network file system (EFS), triggered by a large internal data transfer while preloading the tile cache.
 This caused the map server processes to stall while waiting for IO operations to complete.
+
 The issue was resolved by reducing the load on the file system.
 
 #### [2026-05-06 11:03] Issues with WMS and WMTS noticed


### PR DESCRIPTION
CC @Luke252

[Test link](https://sys-docs.dev.bgdi.ch/preview/add-incident-log-on-what-caused-wms-wmts-interruption/index.html)