### PR TITLE
Style the incident banner

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -143,6 +143,10 @@ figcaption {
     width: 100%;
 }
 
+.status-container p {
+    padding: 1rem 0;
+}
+
 .status-warning {
     background-color: var(--vp-custom-block-warning-bg);
     color: var(--vp-custom-block-warning-text);
@@ -168,9 +172,9 @@ figcaption {
 .status-content {
     padding: 10px 30px;
     width: 100%;
-    height: 64px;
     display: flex;
     align-items: center;
+    display: block;
 }
 
 .status-content-title {


### PR DESCRIPTION
* Give it some padding so that the text doesn't stick to the top and bottom
* Make the container flexible in height

<img width="1595" height="270" alt="image" src="https://github.com/user-attachments/assets/ac3dba5e-9f71-42d4-b486-f11c878c11dd" />

instead of

<img width="1509" height="220" alt="image" src="https://github.com/user-attachments/assets/0e83695c-3e44-49be-adf2-55663ddb6e4f" />


[Test link](https://sys-docs.dev.bgdi.ch/preview/feat-style-incident-thing/index.html)