### PR TITLE
PB-2093 Small fix to test CI changes #patch

### DIFF
--- a/releases/20260506.md
+++ b/releases/20260506.md
@@ -6,19 +6,14 @@ sidebar: true
 
 # Release 20260506 - May 6th 2026
 
-### API & applications
+## API
 
-### API
-
-- Bug fixes:
-
-- Announcements:
-  - The layer ch.bafu.trockenheitsindex does now show the status up to the previous week, rather than the status for the current week, as previously announced.
-  - The layers ch.bafu.silvaprotect-\* are now visible in the eCH and INSPIRE topics within the mapviewer.
+- Layer _ch.bafu.trockenheitsindex_ now shows the status up to the previous week, rather than the status for the current week, as previously announced.
+- Layers _ch.bafu.silvaprotect-\*_ are now visible in the eCH and INSPIRE topics within the mapviewer.
 
 - [Full changelog](https://github.com/geoadmin/mf-chsdi3/compare/2026-03-18-rc4...2026-05-06-rc1)
 
-### Geodata
+## Geodata
 
 | Status | Layer                                                                                                                                                                                                     |
 | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
This aligns the titles of page [Release 20260318](https://docs.geo.admin.ch/releases/20260318.html) with the other pages plus other small formatting / style corrections.

The purpose of this is mainly to check that the changes of https://github.com/geoadmin/infra-terraform-bgdi/pull/1549 work as expected.

[Test link](https://sys-docs.dev.bgdi.ch/preview/feat-pb-2093-small-fix-to-test-ci-changes/index.html)