### PR TITLE
PB-2303: fix status banner clickability on narrow screens #patch

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -141,6 +141,8 @@ figcaption {
 
 .status-container {
     width: 100%;
+    position: relative;
+    z-index: 1;
 }
 
 .status-warning {


### PR DESCRIPTION
Fixes the status banner stacking order so warning and danger banners remain clickable on narrow screens. No content or layout-geometry changes.

Tested with `pnpm run format:check`, `pnpm run docs:build`, and narrow/desktop click-through.

No pre-merge steps required.


[Test link](https://sys-docs.dev.bgdi.ch/preview/fix-pb-2303-status-banner-mobile-click/index.html)