### PR TITLE
Refactor: Add Makefile #patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: setup serve format format-check
+
+setup:
+	pnpm install
+
+serve:
+	pnpm run docs:dev
+
+format:
+	pnpm run format
+
+format-check:
+	pnpm run format:check

--- a/README.md
+++ b/README.md
@@ -11,20 +11,25 @@ Technical documentation for services made available by geo.admin.ch.
 
 To build and run the site locally:
 
-1. Make sure Node.js v22 or higher is installed (`node -v`). If you have `nvm` installed you should have automatically the correct version due to `.nvmrc`
-2. Optional: Activate a suitable Node version, e.g. with `nvm use stable`
-   ℹ️ Use `nvm list` to see all available Node versions
-3. Run `pnpm install` to locally install all the necessary packages
-4. Run `pnpm run docs:dev` and visit http://localhost:5173/ in your web browser
+1. Make sure Node.js v22 or higher is installed (`node -v`). If you have `nvm` installed you should have automatically the correct version due to `.nvmrc`.
+2. Run `make setup` to locally install all the necessary packages.
+3. Run `make serve` and open http://localhost:5173/ in your web browser.
 
 ## Development
 
 This project uses the [prettier](https://prettier.io/) package for formatting.
 
-You can automatically run prettier with these commands:
+To check formatting:
 
-1. `pnpm run format`
-2. `pnpm run format:check`
+```sh
+make format-check
+```
+
+To format your files:
+
+```sh
+make format
+```
 
 ## How to Add a Release Note
 


### PR DESCRIPTION
When reviewing https://github.com/geoadmin/doc-tech/pull/170 I noticed that one forgets the right commands to setup/serve/format the project. So, as in all other projects, I have created a minimal Makefile to avoid that.

The commands:

- `make setup` → `pnpm install`
- `make serve` → `pnpm run docs:dev`
- `make format` → `pnpm run format`
- `make format-check` → `pnpm run format:check`

I did not add a help message or something like that as I find it easier to have an easily grokable Makefile than a lot of comments etc in it.

[Test link](https://sys-docs.dev.bgdi.ch/preview/feat-add-makefile/index.html)