### PR TITLE
CHORE: Change vector tiles specs reference to MapLibre #patch

### DIFF
--- a/visualize-data/vector-tiles.md
+++ b/visualize-data/vector-tiles.md
@@ -1,6 +1,6 @@
 # Vector Tiles
 
-This service delivers vector map tiles and styles through a RESTful API, implementing the [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/).
+This service delivers vector map tiles and styles through a RESTful API. The vector tiles are provided according to the [Mapbox Vector Tile Specification](https://mapbox.github.io/vector-tile-spec/) while the map styles implement the [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/), ensuring compatibility with MapLibre-based clients and other applications supporting the specification.
 
 ::: tip
 [The corresponding page on geo.admin.ch](https://www.geo.admin.ch/en/vector-tiles-service-available-services-and-data) lists the available datasets and styles.

--- a/visualize-data/vector-tiles.md
+++ b/visualize-data/vector-tiles.md
@@ -1,6 +1,6 @@
 # Vector Tiles
 
-This service delivers vector map tiles and styles through a RESTful API, implementing the [Mapbox Vector Tiles specification](https://www.mapbox.com/vector-tiles).
+This service delivers vector map tiles and styles through a RESTful API, implementing the [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/).
 
 ::: tip
 [The corresponding page on geo.admin.ch](https://www.geo.admin.ch/en/vector-tiles-service-available-services-and-data) lists the available datasets and styles.


### PR DESCRIPTION
Following a comment by Karsten Pippig (swisstopo):

> The Mapbox Vector Tile Specification describes the format of vector tiles. The styles, however, are provided in accordance with the MapLibre Style Specification (formerly the Mapbox Style Specification). We should therefore refer to the relevant specification when discussing the styles: https://maplibre.org/maplibre-style-spec/

[Test link](https://sys-docs.dev.bgdi.ch/preview/chore-change-vector-tiles-specs-reference-to-maplibre/index.html)